### PR TITLE
Mask link to source blob

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,10 +49,12 @@ runs:
       name: Get link to source blob
       shell: bash
       run: |
-        echo ::set-output name=link::$(\
+        link_blob=$(\
           curl -fsS 'https://api.github.com/repos/${{ inputs.github_repo }}/tarball/${{ inputs.ref }}' \
           -H "Authorization: token ${{ inputs.github_token }}" -D - -o /dev/null | awk -v RS='\r\n' -v OFS='' -F'location: ' '$2 {print $2}' \
         )
+        echo "::add-mask::$link_blob"
+        echo ::set-output name=link::$link_blob
     - id: create_build
       name: Create Heroku build
       shell: bash


### PR DESCRIPTION
I found that the generated URL contains a token, for security reason, we should mask the output of `Get link to source blob`

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-log